### PR TITLE
Loader cache decorators

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		5B82E88329150576000F4D6F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E88229150576000F4D6F /* Assets.xcassets */; };
 		5B82E88629150576000F4D6F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E88429150576000F4D6F /* LaunchScreen.storyboard */; };
 		5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */; };
+		5BC8E42A291B944900C1ADB7 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */; };
 		5BD06558291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD06557291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift */; };
 		5BD0655C291A434A00642446 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0655A291A42EE00642446 /* XCTestCase+MemoryLeakTracking.swift */; };
 		5BD0655E291A439100642446 /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0655D291A439100642446 /* SharedTestHelpers.swift */; };
@@ -67,6 +68,7 @@
 		5B82E88729150576000F4D6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5B82E88C29150576000F4D6F /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		5BD06557291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		5BD0655A291A42EE00642446 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		5BD0655D291A439100642446 /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 			children = (
 				5BD0655A291A42EE00642446 /* XCTestCase+MemoryLeakTracking.swift */,
 				5BD0655D291A439100642446 /* SharedTestHelpers.swift */,
+				5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 				5B696B2E29197D9B001F25D9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				5B696B262918F5B6001F25D9 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
+				5BC8E42A291B944900C1ADB7 /* FeedLoaderStub.swift in Sources */,
 				5BD0655C291A434A00642446 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */; };
 		5BC8E42A291B944900C1ADB7 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */; };
 		5BC8E42C291B956500C1ADB7 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */; };
+		5BC8E430291B9C7700C1ADB7 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E42F291B9C7700C1ADB7 /* FeedLoaderCacheDecorator.swift */; };
 		5BD06558291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD06557291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift */; };
 		5BD0655C291A434A00642446 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0655A291A42EE00642446 /* XCTestCase+MemoryLeakTracking.swift */; };
 		5BD0655E291A439100642446 /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0655D291A439100642446 /* SharedTestHelpers.swift */; };
@@ -71,6 +72,7 @@
 		5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
+		5BC8E42F291B9C7700C1ADB7 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		5BD06557291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		5BD0655A291A42EE00642446 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		5BD0655D291A439100642446 /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				5B82E88729150576000F4D6F /* Info.plist */,
 				5B696B2929194373001F25D9 /* FeedLoaderWithFallbackComposite.swift */,
 				5BD06557291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift */,
+				5BC8E42F291B9C7700C1ADB7 /* FeedLoaderCacheDecorator.swift */,
 			);
 			path = EssentialApp;
 			sourceTree = "<group>";
@@ -268,6 +271,7 @@
 				5B82E87E29150574000F4D6F /* ViewController.swift in Sources */,
 				5B82E87A29150574000F4D6F /* AppDelegate.swift in Sources */,
 				5B696B2A29194373001F25D9 /* FeedLoaderWithFallbackComposite.swift in Sources */,
+				5BC8E430291B9C7700C1ADB7 /* FeedLoaderCacheDecorator.swift in Sources */,
 				5B82E87C29150574000F4D6F /* SceneDelegate.swift in Sources */,
 				5BD06558291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 			);

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		5B920DB4291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DB3291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		5B920DB6291C3F780056677F /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DB5291C3F780056677F /* FeedImageDataLoaderSpy.swift */; };
 		5B920DB8291C401D0056677F /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DB7291C401D0056677F /* XCTestCase+FeedImageDataLoader.swift */; };
+		5B920DBC291C429C0056677F /* FeedImageDataLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DBB291C429C0056677F /* FeedImageDataLoaderCacheDecorator.swift */; };
 		5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */; };
 		5BC8E42A291B944900C1ADB7 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */; };
 		5BC8E42C291B956500C1ADB7 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */; };
@@ -75,6 +76,7 @@
 		5B920DB3291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		5B920DB5291C3F780056677F /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		5B920DB7291C401D0056677F /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
+		5B920DBB291C429C0056677F /* FeedImageDataLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 				5B696B2929194373001F25D9 /* FeedLoaderWithFallbackComposite.swift */,
 				5BD06557291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift */,
 				5BC8E42F291B9C7700C1ADB7 /* FeedLoaderCacheDecorator.swift */,
+				5B920DBB291C429C0056677F /* FeedImageDataLoaderCacheDecorator.swift */,
 			);
 			path = EssentialApp;
 			sourceTree = "<group>";
@@ -283,6 +286,7 @@
 				5BC8E430291B9C7700C1ADB7 /* FeedLoaderCacheDecorator.swift in Sources */,
 				5B82E87C29150574000F4D6F /* SceneDelegate.swift in Sources */,
 				5BD06558291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
+				5B920DBC291C429C0056677F /* FeedImageDataLoaderCacheDecorator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		5B82E88629150576000F4D6F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E88429150576000F4D6F /* LaunchScreen.storyboard */; };
 		5B920DB4291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DB3291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		5B920DB6291C3F780056677F /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DB5291C3F780056677F /* FeedImageDataLoaderSpy.swift */; };
+		5B920DB8291C401D0056677F /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DB7291C401D0056677F /* XCTestCase+FeedImageDataLoader.swift */; };
 		5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */; };
 		5BC8E42A291B944900C1ADB7 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */; };
 		5BC8E42C291B956500C1ADB7 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */; };
@@ -73,6 +74,7 @@
 		5B82E88C29150576000F4D6F /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B920DB3291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		5B920DB5291C3F780056677F /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
+		5B920DB7291C401D0056677F /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
 		5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
@@ -167,6 +169,7 @@
 				5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */,
 				5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */,
 				5B920DB5291C3F780056677F /* FeedImageDataLoaderSpy.swift */,
+				5B920DB7291C401D0056677F /* XCTestCase+FeedImageDataLoader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -290,6 +293,7 @@
 				5BD0655E291A439100642446 /* SharedTestHelpers.swift in Sources */,
 				5B920DB4291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				5BC8E42C291B956500C1ADB7 /* XCTestCase+FeedLoader.swift in Sources */,
+				5B920DB8291C401D0056677F /* XCTestCase+FeedImageDataLoader.swift in Sources */,
 				5B696B2E29197D9B001F25D9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				5B920DB6291C3F780056677F /* FeedImageDataLoaderSpy.swift in Sources */,
 				5B696B262918F5B6001F25D9 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		5B82E88129150574000F4D6F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E87F29150574000F4D6F /* Main.storyboard */; };
 		5B82E88329150576000F4D6F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E88229150576000F4D6F /* Assets.xcassets */; };
 		5B82E88629150576000F4D6F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E88429150576000F4D6F /* LaunchScreen.storyboard */; };
+		5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */; };
 		5BD06558291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD06557291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift */; };
 		5BD0655C291A434A00642446 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0655A291A42EE00642446 /* XCTestCase+MemoryLeakTracking.swift */; };
 		5BD0655E291A439100642446 /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0655D291A439100642446 /* SharedTestHelpers.swift */; };
@@ -65,6 +66,7 @@
 		5B82E88529150576000F4D6F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		5B82E88729150576000F4D6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5B82E88C29150576000F4D6F /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		5BD06557291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		5BD0655A291A42EE00642446 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		5BD0655D291A439100642446 /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 				5BD06559291A42BA00642446 /* Helpers */,
 				5B696B252918F5B6001F25D9 /* FeedLoaderWithFallbackCompositeTests.swift */,
 				5B696B2D29197D9B001F25D9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
+				5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -271,6 +274,7 @@
 				5BD0655E291A439100642446 /* SharedTestHelpers.swift in Sources */,
 				5B696B2E29197D9B001F25D9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				5B696B262918F5B6001F25D9 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
+				5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				5BD0655C291A434A00642446 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		5B82E88329150576000F4D6F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E88229150576000F4D6F /* Assets.xcassets */; };
 		5B82E88629150576000F4D6F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E88429150576000F4D6F /* LaunchScreen.storyboard */; };
 		5B920DB4291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DB3291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
+		5B920DB6291C3F780056677F /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DB5291C3F780056677F /* FeedImageDataLoaderSpy.swift */; };
 		5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */; };
 		5BC8E42A291B944900C1ADB7 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */; };
 		5BC8E42C291B956500C1ADB7 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */; };
@@ -71,6 +72,7 @@
 		5B82E88729150576000F4D6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5B82E88C29150576000F4D6F /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B920DB3291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		5B920DB5291C3F780056677F /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
@@ -164,6 +166,7 @@
 				5BD0655D291A439100642446 /* SharedTestHelpers.swift */,
 				5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */,
 				5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */,
+				5B920DB5291C3F780056677F /* FeedImageDataLoaderSpy.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				5B920DB4291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				5BC8E42C291B956500C1ADB7 /* XCTestCase+FeedLoader.swift in Sources */,
 				5B696B2E29197D9B001F25D9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
+				5B920DB6291C3F780056677F /* FeedImageDataLoaderSpy.swift in Sources */,
 				5B696B262918F5B6001F25D9 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				5BC8E42A291B944900C1ADB7 /* FeedLoaderStub.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		5B82E88629150576000F4D6F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E88429150576000F4D6F /* LaunchScreen.storyboard */; };
 		5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */; };
 		5BC8E42A291B944900C1ADB7 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */; };
+		5BC8E42C291B956500C1ADB7 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */; };
 		5BD06558291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD06557291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift */; };
 		5BD0655C291A434A00642446 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0655A291A42EE00642446 /* XCTestCase+MemoryLeakTracking.swift */; };
 		5BD0655E291A439100642446 /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD0655D291A439100642446 /* SharedTestHelpers.swift */; };
@@ -69,6 +70,7 @@
 		5B82E88C29150576000F4D6F /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
+		5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		5BD06557291A421300642446 /* FeedImageDataLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		5BD0655A291A42EE00642446 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		5BD0655D291A439100642446 /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				5BD0655A291A42EE00642446 /* XCTestCase+MemoryLeakTracking.swift */,
 				5BD0655D291A439100642446 /* SharedTestHelpers.swift */,
 				5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */,
+				5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5BD0655E291A439100642446 /* SharedTestHelpers.swift in Sources */,
+				5BC8E42C291B956500C1ADB7 /* XCTestCase+FeedLoader.swift in Sources */,
 				5B696B2E29197D9B001F25D9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				5B696B262918F5B6001F25D9 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		5B82E88129150574000F4D6F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E87F29150574000F4D6F /* Main.storyboard */; };
 		5B82E88329150576000F4D6F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E88229150576000F4D6F /* Assets.xcassets */; };
 		5B82E88629150576000F4D6F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5B82E88429150576000F4D6F /* LaunchScreen.storyboard */; };
+		5B920DB4291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DB3291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		5BC8E428291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */; };
 		5BC8E42A291B944900C1ADB7 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */; };
 		5BC8E42C291B956500C1ADB7 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */; };
@@ -69,6 +70,7 @@
 		5B82E88529150576000F4D6F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		5B82E88729150576000F4D6F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5B82E88C29150576000F4D6F /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B920DB3291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		5BC8E429291B944900C1ADB7 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		5BC8E42B291B956500C1ADB7 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 				5B696B252918F5B6001F25D9 /* FeedLoaderWithFallbackCompositeTests.swift */,
 				5B696B2D29197D9B001F25D9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
 				5BC8E427291B916600C1ADB7 /* FeedLoaderCacheDecoratorTests.swift */,
+				5B920DB3291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -282,6 +285,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5BD0655E291A439100642446 /* SharedTestHelpers.swift in Sources */,
+				5B920DB4291C3DCB0056677F /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				5BC8E42C291B956500C1ADB7 /* XCTestCase+FeedLoader.swift in Sources */,
 				5B696B2E29197D9B001F25D9 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				5B696B262918F5B6001F25D9 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -20,9 +20,15 @@ public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
         return decoratee.loadImageData(from: url) { [weak self] result in
             completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
+                self?.cache.saveIgnoringResult(data, for: url)
                 return data
             })
         }
     }
 }
+
+private extension FeedImageDataCache {
+     func saveIgnoringResult(_ data: Data, for url: URL) {
+         save(data, for: url) { _ in }
+     }
+ }

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -1,0 +1,28 @@
+//
+//  FeedImageDataLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by tamorim on 09/11/2022.
+//
+
+import Foundation
+import EssentialFeed
+
+public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    private let decoratee: FeedImageDataLoader
+    private let cache: FeedImageDataCache
+    
+    public init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+    
+    public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        return decoratee.loadImageData(from: url) { [weak self] result in
+            completion(result.map { data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            })
+        }
+    }
+}

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -1,0 +1,28 @@
+//
+//  FeedLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by tamorim on 09/11/2022.
+//
+
+import EssentialFeed
+
+public final class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+    private let cache: FeedCache
+    
+    public init(decoratee: FeedLoader, cache: FeedCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+    
+   public func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load { [weak self] result in
+            if let feed = try? result.get() {
+                self?.cache.save(feed) { _ in }
+            }
+            
+            completion(result)
+        }
+    }
+}

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -19,10 +19,16 @@ public final class FeedLoaderCacheDecorator: FeedLoader {
    public func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
             if let feed = try? result.get() {
-                self?.cache.save(feed) { _ in }
+                self?.cache.saveIgnoringResult(feed)
             }
             
             completion(result)
         }
+    }
+}
+
+private extension FeedCache {
+    func saveIgnoringResult(_ feed: [FeedImage]) {
+        save(feed) { _ in }
     }
 }

--- a/EssentialApp/EssentialApp/SceneDelegate.swift
+++ b/EssentialApp/EssentialApp/SceneDelegate.swift
@@ -31,7 +31,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         
         window?.rootViewController = FeedUIComposer.feedComposeWith(
-            feedLoader: FeedLoaderWithFallbackComposite(primary: remoteFeedLoader,
+            feedLoader: FeedLoaderWithFallbackComposite(primary: FeedLoaderCacheDecorator(decoratee: remoteFeedLoader,
+                                                                                          cache: localFeedLoader),
                                                         fallback: localFeedLoader),
             imageLoader: FeedImageDataLoaderWithFallbackComposite(primary: localImageLoader,
                                                                   fallback: remoteImageLoader))

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -9,12 +9,6 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-protocol FeedImageDataCache {
-    typealias Result = Swift.Result<Void, Error>
-    
-    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
-}
-
 class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     private let decoratee: FeedImageDataLoader
     private let cache: FeedImageDataCache

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -22,7 +22,7 @@ class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
  }
 
 
-final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
 
     func test_init_doesNotLoadImageData() {
          let (_, loader) = makeSUT()
@@ -74,29 +74,6 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
          trackForMemoryLeaks(loader, file: file, line: line)
          trackForMemoryLeaks(sut, file: file, line: line)
          return (sut, loader)
-     }
-
-     private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-         let exp = expectation(description: "Wait for load completion")
-
-         _ = sut.loadImageData(from: anyURL()) { receivedResult in
-             switch (receivedResult, expectedResult) {
-             case let (.success(receivedFeed), .success(expectedFeed)):
-                 XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-
-             case (.failure, .failure):
-                 break
-
-             default:
-                 XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-             }
-
-             exp.fulfill()
-         }
-
-         action()
-
-         wait(for: [exp], timeout: 1.0)
      }
 
      private class FeedImageDataLoaderSpy: FeedImageDataLoader {

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -26,8 +26,10 @@ class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     
     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
         return decoratee.loadImageData(from: url) { [weak self] result in
-            self?.cache.save((try? result.get()) ?? Data(), for: url) { _ in }
-            completion(result)
+            completion(result.map { data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            })
         }
     }
 }
@@ -87,6 +89,17 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoa
         loader.complete(with: imageData)
         
         XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+    }
+    
+    func test_loadImageData_doesNotCacheDataOnLoaderFailure() {
+        let cache = CacheSpy()
+        let url = anyURL()
+        let (sut, loader) = makeSUT(cache: cache)
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        loader.complete(with: anyNSError())
+        
+        XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache image data on load error")
     }
 
      // MARK: - Helpers

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -9,17 +9,28 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
+protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}
+
 class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
-     private let decoratee: FeedImageDataLoader
-
-     init(decoratee: FeedImageDataLoader) {
-         self.decoratee = decoratee
-     }
-
-     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-         return decoratee.loadImageData(from: url, completion: completion)
-     }
- }
+    private let decoratee: FeedImageDataLoader
+    private let cache: FeedImageDataCache
+    
+    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+    
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        return decoratee.loadImageData(from: url) { [weak self] result in
+            self?.cache.save((try? result.get()) ?? Data(), for: url) { _ in }
+            completion(result)
+        }
+    }
+}
 
 
 final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
@@ -65,44 +76,40 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoa
              loader.complete(with: anyNSError())
          })
      }
+    
+    func test_loadImageData_cachesLoadedDataOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let url = anyURL()
+        let imageData = anyData()
+        let (sut, loader) = makeSUT(cache: cache)
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        loader.complete(with: imageData)
+        
+        XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+    }
 
      // MARK: - Helpers
-         
-     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
-         let loader = FeedImageDataLoaderSpy()
-         let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
-         trackForMemoryLeaks(loader, file: file, line: line)
-         trackForMemoryLeaks(sut, file: file, line: line)
-         return (sut, loader)
+    
+    private func makeSUT(cache: CacheSpy = .init(), file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
+        let loader = FeedImageDataLoaderSpy()
+        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader, cache: cache)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return (sut, loader)
      }
-
-     private class FeedImageDataLoaderSpy: FeedImageDataLoader {
-         private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-
-         private(set) var cancelledURLs = [URL]()
-
-         var loadedURLs: [URL] {
-             return messages.map { $0.url }
-         }
-
-         private struct Task: FeedImageDataLoaderTask {
-             let callback: () -> Void
-             func cancel() { callback() }
-         }
-
-         func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-             messages.append((url, completion))
-             return Task { [weak self] in
-                 self?.cancelledURLs.append(url)
-             }
-         }
-
-         func complete(with error: Error, at index: Int = 0) {
-             messages[index].completion(.failure(error))
-         }
-
-         func complete(with data: Data, at index: Int = 0) {
-             messages[index].completion(.success(data))
-         }
-     }
+    
+    
+    private class CacheSpy: FeedImageDataCache {
+        private(set) var messages = [Message]()
+        
+        enum Message: Equatable {
+            case save(data: Data, for: URL)
+        }
+        
+        func save(_ data: Data, for url: URL, completion: @escaping (FeedImageDataCache.Result) -> Void) {
+            messages.append(.save(data: data, for: url))
+            completion(.success(()))
+        }
+    }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -1,0 +1,131 @@
+//
+//  FeedImageDataLoaderCacheDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by tamorim on 09/11/2022.
+//
+
+import XCTest
+import EssentialFeed
+import EssentialApp
+
+class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+     private let decoratee: FeedImageDataLoader
+
+     init(decoratee: FeedImageDataLoader) {
+         self.decoratee = decoratee
+     }
+
+     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+         return decoratee.loadImageData(from: url, completion: completion)
+     }
+ }
+
+
+final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+
+    func test_init_doesNotLoadImageData() {
+         let (_, loader) = makeSUT()
+
+         XCTAssertTrue(loader.loadedURLs.isEmpty, "Expected no loaded URLs")
+     }
+
+     func test_loadImageData_loadsFromLoader() {
+         let url = anyURL()
+         let (sut, loader) = makeSUT()
+
+         _ = sut.loadImageData(from: url) { _ in }
+
+         XCTAssertEqual(loader.loadedURLs, [url], "Expected to load URL from loader")
+     }
+
+     func test_cancelLoadImageData_cancelsLoaderTask() {
+         let url = anyURL()
+         let (sut, loader) = makeSUT()
+
+         let task = sut.loadImageData(from: url) { _ in }
+         task.cancel()
+
+         XCTAssertEqual(loader.cancelledURLs, [url], "Expected to cancel URL loading from loader")
+     }
+
+     func test_loadImageData_deliversDataOnLoaderSuccess() {
+         let imageData = anyData()
+         let (sut, loader) = makeSUT()
+
+         expect(sut, toCompleteWith: .success(imageData), when: {
+             loader.complete(with: imageData)
+         })
+     }
+
+     func test_loadImageData_deliversErrorOnLoaderFailure() {
+         let (sut, loader) = makeSUT()
+
+         expect(sut, toCompleteWith: .failure(anyNSError()), when: {
+             loader.complete(with: anyNSError())
+         })
+     }
+
+     // MARK: - Helpers
+         
+     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: LoaderSpy) {
+         let loader = LoaderSpy()
+         let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+         trackForMemoryLeaks(loader, file: file, line: line)
+         trackForMemoryLeaks(sut, file: file, line: line)
+         return (sut, loader)
+     }
+
+     private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+         let exp = expectation(description: "Wait for load completion")
+
+         _ = sut.loadImageData(from: anyURL()) { receivedResult in
+             switch (receivedResult, expectedResult) {
+             case let (.success(receivedFeed), .success(expectedFeed)):
+                 XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+
+             case (.failure, .failure):
+                 break
+
+             default:
+                 XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+             }
+
+             exp.fulfill()
+         }
+
+         action()
+
+         wait(for: [exp], timeout: 1.0)
+     }
+
+     private class LoaderSpy: FeedImageDataLoader {
+         private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+
+         private(set) var cancelledURLs = [URL]()
+
+         var loadedURLs: [URL] {
+             return messages.map { $0.url }
+         }
+
+         private struct Task: FeedImageDataLoaderTask {
+             let callback: () -> Void
+             func cancel() { callback() }
+         }
+
+         func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+             messages.append((url, completion))
+             return Task { [weak self] in
+                 self?.cancelledURLs.append(url)
+             }
+         }
+
+         func complete(with error: Error, at index: Int = 0) {
+             messages[index].completion(.failure(error))
+         }
+
+         func complete(with data: Data, at index: Int = 0) {
+             messages[index].completion(.success(data))
+         }
+     }
+}

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -9,26 +9,6 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
-    private let decoratee: FeedImageDataLoader
-    private let cache: FeedImageDataCache
-    
-    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-    
-    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-        return decoratee.loadImageData(from: url) { [weak self] result in
-            completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
-                return data
-            })
-        }
-    }
-}
-
-
 final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
 
     func test_init_doesNotLoadImageData() {

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -68,8 +68,8 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
 
      // MARK: - Helpers
          
-     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: LoaderSpy) {
-         let loader = LoaderSpy()
+     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
+         let loader = FeedImageDataLoaderSpy()
          let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
          trackForMemoryLeaks(loader, file: file, line: line)
          trackForMemoryLeaks(sut, file: file, line: line)
@@ -99,7 +99,7 @@ final class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
          wait(for: [exp], timeout: 1.0)
      }
 
-     private class LoaderSpy: FeedImageDataLoader {
+     private class FeedImageDataLoaderSpy: FeedImageDataLoader {
          private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
 
          private(set) var cancelledURLs = [URL]()

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -92,9 +92,9 @@ final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
     
     //MARK: - Helpers
     
-    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: LoaderSpy, fallback: LoaderSpy) {
-        let primaryLoader = LoaderSpy()
-        let fallbackLoader = LoaderSpy()
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: FeedImageDataLoaderSpy, fallback: FeedImageDataLoaderSpy) {
+        let primaryLoader = FeedImageDataLoaderSpy()
+        let fallbackLoader = FeedImageDataLoaderSpy()
         let sut = FeedImageDataLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         trackForMemoryLeaks(primaryLoader, file: file, line: line)
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -123,37 +123,5 @@ final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         
         action()
         wait(for: [exp], timeout: 1.0)
-    }
-    
-    private class LoaderSpy: FeedImageDataLoader {
-        private var messages = [(url: URL, completion: ((FeedImageDataLoader.Result) -> Void))]()
-        
-        private(set) var cancelledURLs = [URL]()
-        
-        var loadedURLs: [URL] {
-            messages.map { $0.url }
-        }
-        
-        private struct Task: FeedImageDataLoaderTask {
-            let callback: () -> Void
-            func cancel() {
-                callback()
-            }
-        }
-        
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-        
-        func complete(with data: Data, at index: Int = 0) {
-            messages[index].completion(.success(data))
-        }
-        
-        func complete(with error: NSError, at index: Int = 0) {
-            messages[index].completion(.failure(error))
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
+final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase, FeedImageDataLoaderTestCase {
     
     func test_init_doesNotLoadImageData() {
         let (_, primaryLoader, fallbackLoader) = makeSUT()
@@ -101,27 +101,5 @@ final class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(sut, file: file, line: line)
         
         return (sut, primaryLoader, fallbackLoader)
-    }
-    
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for loader completion")
-        
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-            
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        action()
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -59,8 +59,4 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase {
         
         wait(for: [exp], timeout: 1.0)
     }
-    
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,15 +8,26 @@
 import XCTest
 import EssentialFeed
 
+protocol FeedCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}
+
 class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
+    private let cache: FeedCache
     
-    init(decoratee: FeedLoader) {
+    init(decoratee: FeedLoader, cache: FeedCache) {
         self.decoratee = decoratee
+        self.cache = cache
     }
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load(completion: completion)
+        decoratee.load { [weak self] result in
+            self?.cache.save((try? result.get()) ?? []) { _ in }
+            completion(result)
+        }
     }
 }
 
@@ -35,14 +46,37 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
         expect(sut, toCompleteWith: .failure(anyNSError()))
     }
     
+    func test_load_cachesLoadedFeedOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let feed = uniqueFeed()
+        let sut = makeSUT(loaderResult: .success(feed), cache: cache)
+        
+        sut.load { _ in }
+        
+        XCTAssertEqual(cache.messages, [.save(feed)], "Expect to cache loaded feed on success")
+    }
+    
     //MARK: - Helpers
     
-    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+    private func makeSUT(loaderResult: FeedLoader.Result, cache: CacheSpy = .init(), file: StaticString = #file, line: UInt = #line) -> FeedLoader {
         let loader = FeedLoaderStub(result: loaderResult)
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         
         return sut
+    }
+    
+    private class CacheSpy: FeedCache {
+        private(set) var messages = [Message]()
+        
+        enum Message: Equatable {
+            case save([FeedImage])
+        }
+        
+        func save(_ feed: [FeedImage], completion: @escaping (FeedCache.Result) -> Void) {
+            messages.append(.save(feed))
+            completion(.success(()))
+        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,14 +24,14 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase {
     
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = LoaderStub(result: .success(feed))
+        let loader = FeedLoaderStub(result: .success(feed))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
         
         expect(sut, toCompleteWith: .success(feed))
     }
     
     func test_load_deliversErrorOnLoaderFailure() {
-        let loader = LoaderStub(result: .failure(anyNSError()))
+        let loader = FeedLoaderStub(result: .failure(anyNSError()))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
         
         expect(sut, toCompleteWith: .failure(anyNSError()))
@@ -62,17 +62,5 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase {
     
     private func uniqueFeed() -> [FeedImage] {
         return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
-    
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-        
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-        
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,16 +24,25 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = FeedLoaderStub(result: .success(feed))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .success(feed))
         
         expect(sut, toCompleteWith: .success(feed))
     }
     
     func test_load_deliversErrorOnLoaderFailure() {
-        let loader = FeedLoaderStub(result: .failure(anyNSError()))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .failure(anyNSError()))
         
         expect(sut, toCompleteWith: .failure(anyNSError()))
+    }
+    
+    //MARK: - Helpers
+    
+    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+        let loader = FeedLoaderStub(result: loaderResult)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        
+        return sut
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -1,0 +1,78 @@
+//
+//  FeedLoaderCacheDecorator.swift
+//  EssentialAppTests
+//
+//  Created by tamorim on 09/11/2022.
+//
+
+import XCTest
+import EssentialFeed
+
+class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+    
+    init(decoratee: FeedLoader) {
+        self.decoratee = decoratee
+    }
+    
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load(completion: completion)
+    }
+}
+
+final class FeedLoaderCacheDecoratorTests: XCTestCase {
+    
+    func test_load_deliversFeedOnLoaderSuccess() {
+        let feed = uniqueFeed()
+        let loader = LoaderStub(result: .success(feed))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        
+        expect(sut, toCompleteWith: .success(feed))
+    }
+    
+    func test_load_deliversErrorOnLoaderFailure() {
+        let loader = LoaderStub(result: .failure(anyNSError()))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        
+        expect(sut, toCompleteWith: .failure(anyNSError()))
+    }
+    
+    //MARK: - Helpers
+    
+    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    private func uniqueFeed() -> [FeedImage] {
+        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
+    }
+    
+    private class LoaderStub: FeedLoader {
+        private let result: FeedLoader.Result
+        
+        init(result: FeedLoader.Result) {
+            self.result = result
+        }
+        
+        func load(completion: @escaping (FeedLoader.Result) -> Void) {
+            completion(result)
+        }
+    }
+}

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,7 +25,10 @@ class FeedLoaderCacheDecorator: FeedLoader {
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            self?.cache.save((try? result.get()) ?? []) { _ in }
+            if let feed = try? result.get() {
+                self?.cache.save(feed) { _ in }
+            }
+            
             completion(result)
         }
     }
@@ -54,6 +57,15 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
         sut.load { _ in }
         
         XCTAssertEqual(cache.messages, [.save(feed)], "Expect to cache loaded feed on success")
+    }
+    
+    func test_load_doesNotCacheOnLoaderFailure() {
+        let cache = CacheSpy()
+        let sut = makeSUT(loaderResult: .failure(anyNSError()), cache: cache)
+        
+        sut.load { _ in }
+        
+        XCTAssertTrue(cache.messages.isEmpty, "Expect not to cache feed on load error")
     }
     
     //MARK: - Helpers

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -7,26 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-class FeedLoaderCacheDecorator: FeedLoader {
-    private let decoratee: FeedLoader
-    private let cache: FeedCache
-    
-    init(decoratee: FeedLoader, cache: FeedCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-    
-    func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load { [weak self] result in
-            if let feed = try? result.get() {
-                self?.cache.save(feed) { _ in }
-            }
-            
-            completion(result)
-        }
-    }
-}
+import EssentialApp
 
 final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -20,7 +20,7 @@ class FeedLoaderCacheDecorator: FeedLoader {
     }
 }
 
-final class FeedLoaderCacheDecoratorTests: XCTestCase {
+final class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
@@ -35,28 +35,5 @@ final class FeedLoaderCacheDecoratorTests: XCTestCase {
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
         
         expect(sut, toCompleteWith: .failure(anyNSError()))
-    }
-    
-    //MARK: - Helpers
-    
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,12 +8,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedCache {
-    typealias Result = Swift.Result<Void, Error>
-    
-    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
-}
-
 class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
     private let cache: FeedCache

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -65,8 +65,4 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         
         wait(for: [exp], timeout: 1.0)
     }
-    
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
+final class FeedLoaderWithFallbackCompositeTests: XCTestCase, FeedLoaderTestCase {
 
     func test_load_deliversPrimaryFeedOnPrimaryLoaderSuccess() {
         let primaryFeed = uniqueFeed()
@@ -43,26 +43,5 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(sut, file: file, line: line)
         
         return sut
-    }
-    
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -35,8 +35,8 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     //MARK: - Helpers
     
     private func makeSUT(primaryResult: FeedLoader.Result, fallbackResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
-        let primaryLoader = LoaderStub(result: primaryResult)
-        let fallbackLoader = LoaderStub(result: fallbackResult)
+        let primaryLoader = FeedLoaderStub(result: primaryResult)
+        let fallbackLoader = FeedLoaderStub(result: fallbackResult)
         let sut = FeedLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         trackForMemoryLeaks(primaryLoader, file: file, line: line)
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -68,17 +68,5 @@ final class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     
     private func uniqueFeed() -> [FeedImage] {
         return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-    }
-    
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-        
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-        
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
@@ -1,0 +1,41 @@
+//
+//  FeedImageDataLoaderSpy.swift
+//  EssentialAppTests
+//
+//  Created by tamorim on 09/11/2022.
+//
+
+import Foundation
+import EssentialFeed
+
+class FeedImageDataLoaderSpy: FeedImageDataLoader {
+    private var messages = [(url: URL, completion: ((FeedImageDataLoader.Result) -> Void))]()
+    
+    private(set) var cancelledURLs = [URL]()
+    
+    var loadedURLs: [URL] {
+        messages.map { $0.url }
+    }
+    
+    private struct Task: FeedImageDataLoaderTask {
+        let callback: () -> Void
+        func cancel() {
+            callback()
+        }
+    }
+    
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        messages.append((url, completion))
+        return Task { [weak self] in
+            self?.cancelledURLs.append(url)
+        }
+    }
+    
+    func complete(with data: Data, at index: Int = 0) {
+        messages[index].completion(.success(data))
+    }
+    
+    func complete(with error: NSError, at index: Int = 0) {
+        messages[index].completion(.failure(error))
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
@@ -1,0 +1,21 @@
+//
+//  FeedLoaderStub.swift
+//  EssentialAppTests
+//
+//  Created by tamorim on 09/11/2022.
+//
+
+import Foundation
+import EssentialFeed
+
+class FeedLoaderStub: FeedLoader {
+    private let result: FeedLoader.Result
+    
+    init(result: FeedLoader.Result) {
+        self.result = result
+    }
+    
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        completion(result)
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import EssentialFeed
 
 func anyNSError() -> NSError {
     return NSError(domain: "any error", code: 0)
@@ -17,4 +18,8 @@ func anyURL() -> URL {
 
 func anyData() -> Data {
     return Data("any data".utf8)
+}
+
+func uniqueFeed() -> [FeedImage] {
+    return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
 }

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
@@ -1,0 +1,36 @@
+//
+//  XCTestCase+FeedImageDataLoader.swift
+//  EssentialAppTests
+//
+//  Created by tamorim on 09/11/2022.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedImageDataLoaderTestCase: XCTestCase {}
+
+extension FeedImageDataLoaderTestCase {
+    func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        action()
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
@@ -1,0 +1,34 @@
+//
+//  XCTestCase+FeedLoader.swift
+//  EssentialAppTests
+//
+//  Created by tamorim on 09/11/2022.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedLoaderTestCase: XCTestCase {}
+
+extension FeedLoaderTestCase {
+    func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+}

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		5BC189E828CB2487008451E6 /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC189E728CB2487008451E6 /* SharedTestHelpers.swift */; };
 		5BC384F228F9480F00F41A21 /* FeedImageCellController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC384F128F9480F00F41A21 /* FeedImageCellController.swift */; };
 		5BC384F528F94DB100F41A21 /* FeedUIComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC384F428F94DB100F41A21 /* FeedUIComposer.swift */; };
+		5BC8E42E291B9B9C00C1ADB7 /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC8E42D291B9B9C00C1ADB7 /* FeedCache.swift */; };
 		5BCFC8C428D9A0300072A6B0 /* FeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCFC8C328D9A0300072A6B0 /* FeedStoreSpecs.swift */; };
 		5BCFC8C628D9A0A50072A6B0 /* XCTestCase+FeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCFC8C528D9A0A50072A6B0 /* XCTestCase+FeedStoreSpecs.swift */; };
 		5BCFC8C828D9A1EB0072A6B0 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BCFC8C728D9A1EB0072A6B0 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */; };
@@ -229,6 +230,7 @@
 		5BC384ED28F93EA400F41A21 /* FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoader.swift; sourceTree = "<group>"; };
 		5BC384F128F9480F00F41A21 /* FeedImageCellController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageCellController.swift; sourceTree = "<group>"; };
 		5BC384F428F94DB100F41A21 /* FeedUIComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUIComposer.swift; sourceTree = "<group>"; };
+		5BC8E42D291B9B9C00C1ADB7 /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
 		5BCFC8C328D9A0300072A6B0 /* FeedStoreSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpecs.swift; sourceTree = "<group>"; };
 		5BCFC8C528D9A0A50072A6B0 /* XCTestCase+FeedStoreSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedStoreSpecs.swift"; sourceTree = "<group>"; };
 		5BCFC8C728D9A1EB0072A6B0 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableRetrieveFeedStoreSpecs.swift"; sourceTree = "<group>"; };
@@ -429,6 +431,7 @@
 			children = (
 				5B86F0DF28ACC32C00794424 /* FeedImage.swift */,
 				5B86F0E128ACC3B000794424 /* FeedLoader.swift */,
+				5BC8E42D291B9B9C00C1ADB7 /* FeedCache.swift */,
 			);
 			path = FeedFeature;
 			sourceTree = "<group>";
@@ -906,6 +909,7 @@
 				5BF0883528DC4A0F002F6153 /* ManagedCache.swift in Sources */,
 				5B1ED28F290BC16C0072088F /* FeedViewModel.swift in Sources */,
 				5BE950E6290D6F7000EA0488 /* FeedImageViewModel.swift in Sources */,
+				5BC8E42E291B9B9C00C1ADB7 /* FeedCache.swift in Sources */,
 				5BE950E9290D81E700EA0488 /* FeedImageDataLoader.swift in Sources */,
 				5B86F0E228ACC3B000794424 /* FeedLoader.swift in Sources */,
 				5B0665DC28B13DAB00B2B4E1 /* FeedItemsMapper.swift in Sources */,

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		5B86F0E228ACC3B000794424 /* FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B86F0E128ACC3B000794424 /* FeedLoader.swift */; };
 		5B86F0E528ACC56900794424 /* LoadFeedFromRemoteUseCasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B86F0E428ACC56900794424 /* LoadFeedFromRemoteUseCasesTests.swift */; };
 		5B86F0E928AD15A900794424 /* RemoteFeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B86F0E828AD15A900794424 /* RemoteFeedLoader.swift */; };
+		5B920DBA291C42060056677F /* FeedImageDataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B920DB9291C42060056677F /* FeedImageDataCache.swift */; };
 		5B9BF82428F54C1A00185240 /* FeedImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9BF82328F54C1A00185240 /* FeedImageCell.swift */; };
 		5B9BFA1F2909151B00D3EDE1 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9BFA1E2909151B00D3EDE1 /* ErrorView.swift */; };
 		5B9BFA24290920E600D3EDE1 /* UIRefreshControl+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9BFA23290920E600D3EDE1 /* UIRefreshControl+Helpers.swift */; };
@@ -202,6 +203,7 @@
 		5B86F0E128ACC3B000794424 /* FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoader.swift; sourceTree = "<group>"; };
 		5B86F0E428ACC56900794424 /* LoadFeedFromRemoteUseCasesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCasesTests.swift; sourceTree = "<group>"; };
 		5B86F0E828AD15A900794424 /* RemoteFeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoader.swift; sourceTree = "<group>"; };
+		5B920DB9291C42060056677F /* FeedImageDataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataCache.swift; sourceTree = "<group>"; };
 		5B9BF82328F54C1A00185240 /* FeedImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageCell.swift; sourceTree = "<group>"; };
 		5B9BFA1E2909151B00D3EDE1 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		5B9BFA23290920E600D3EDE1 /* UIRefreshControl+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Helpers.swift"; sourceTree = "<group>"; };
@@ -432,6 +434,7 @@
 				5B86F0DF28ACC32C00794424 /* FeedImage.swift */,
 				5B86F0E128ACC3B000794424 /* FeedLoader.swift */,
 				5BC8E42D291B9B9C00C1ADB7 /* FeedCache.swift */,
+				5B920DB9291C42060056677F /* FeedImageDataCache.swift */,
 			);
 			path = FeedFeature;
 			sourceTree = "<group>";
@@ -898,6 +901,7 @@
 				5B21B23528B8B6C900B576EF /* URLSessionHTTPClient.swift in Sources */,
 				5B9F8CEF2913B33400C5A3AB /* CoreDataFeedStore+FeedImageDataLoader.swift in Sources */,
 				5BE711C8291069CA0093C5B7 /* FeedImageDataStore.swift in Sources */,
+				5B920DBA291C42060056677F /* FeedImageDataCache.swift in Sources */,
 				5B03E01C28C9CE630003E0DA /* RemoteFeedItem.swift in Sources */,
 				5BE950E4290D6EB400EA0488 /* FeedImagePresenter.swift in Sources */,
 				5B86F0E928AD15A900794424 /* RemoteFeedLoader.swift in Sources */,

--- a/EssentialFeed/EssentialFeed/FeedCache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/LocalFeedImageDataLoader.swift
@@ -36,8 +36,8 @@ public class LocalFeedImageDataLoader {
 }
 
 
-extension LocalFeedImageDataLoader {
-    public typealias SaveResult = Result<Void, Swift.Error>
+extension LocalFeedImageDataLoader: FeedImageDataCache {
+    public typealias SaveResult = FeedImageDataCache.Result
     
     public enum SaveError: Error {
         case failed

--- a/EssentialFeed/EssentialFeed/FeedCache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/LocalFeedLoader.swift
@@ -17,8 +17,8 @@ public final class LocalFeedLoader: FeedLoader {
     }
 }
 
-extension LocalFeedLoader {
-    public typealias SaveResult = Result<Void, Error>
+extension LocalFeedLoader: FeedCache {
+    public typealias SaveResult = FeedCache.Result
     
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
         store.deleteCachedFeed { [weak self] deletionResult in

--- a/EssentialFeed/EssentialFeed/FeedFeature/FeedCache.swift
+++ b/EssentialFeed/EssentialFeed/FeedFeature/FeedCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedCache.swift
+//  EssentialFeed
+//
+//  Created by tamorim on 09/11/2022.
+//
+
+import Foundation
+
+public protocol FeedCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}

--- a/EssentialFeed/EssentialFeed/FeedFeature/FeedImageDataCache.swift
+++ b/EssentialFeed/EssentialFeed/FeedFeature/FeedImageDataCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedImageDataCache.swift
+//  EssentialFeed
+//
+//  Created by tamorim on 09/11/2022.
+//
+
+import Foundation
+
+public protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}


### PR DESCRIPTION
Added [*]LoaderCacheDecorators responsible for decorating (intercepting) load operations and injecting the save side-effect on successful load results.

We can now use the decorators to compose the RemoteFeedLoader.loadwith the LocalFeedLoader.save operations in a simple, clean, extendable, modular, and testable way.